### PR TITLE
Enforce G-index in proof validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ export RPC=http://localhost:8000
 forge script script/DeployerFCT.s.sol:DeployFinalizedCheckpointTracker --fork-url $RPC --broadcast -vvvv
 ```
 
-6. Run the checkpoint tracker proof generation and submission. Replace $CHECKPOINT_TRACKER_ADDRESS with the address from the forge script deployment. Use CLI help tools to replace defaults in fields if not using local testnet.
+Copy the address from the output and save it in `CHECKPOINT_TRACKER_ADDRESS`. Example below
+```bash
+  [369311] → new FinalizedCheckpointTracker@0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
+    └─ ← [Return] 1843 bytes of code
+
+export CHECKPOINT_TRACKER_ADDRESS=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
+```
+
+6. Run the checkpoint tracker proof generation and submission. Use CLI help tools to replace defaults in fields if not using local testnet.
 ```bash
 cd ..
 ./proof-generator --checkpoint-tracker-address $CHECKPOINT_TRACKER_ADDRESS --slot 200

--- a/cmd/proof-generator/main.go
+++ b/cmd/proof-generator/main.go
@@ -23,6 +23,7 @@ func main() {
 	checkpointTrackerAddress := flag.String("checkpoint-tracker-address", "", "Checkpoint tracker contract address (required)")
 	slot := flag.Uint64("slot", 230, "Beacon block slot to prove finalized")
 	privateKey := flag.String("pkey", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", "private key to submit proof with")
+	submission := flag.Bool("submit", true, "Enable submission to chain")
 
 	flag.Parse()
 
@@ -61,6 +62,9 @@ func main() {
 	}
 	log.Println("Local proof verification check completed successfully")
 
+	if !*submission {
+		return
+	}
 	// Submit Proof to smart contract
 	log.Println("Submitting proof to smart contract")
 

--- a/internal/checkpointproofs/checkpointproof.go
+++ b/internal/checkpointproofs/checkpointproof.go
@@ -53,6 +53,9 @@ func generateCheckpointProofInputs(ctx context.Context, beaconBlock *consensus.B
 	// Generate the Leaf Value Input and store in leafValue
 	finalizedEpochLeaf := make([]byte, 32)
 	finalizedEpoch := beaconBlock.BeaconState.FinalizedCheckpoint.Epoch
+	if finalizedEpoch == 0 {
+		return nil, errors.New("cannot prove as no epochs have been finalized at this slot")
+	}
 	binary.LittleEndian.PutUint64(finalizedEpochLeaf, finalizedEpoch)
 	var leafValue merkle.Value
 	copy(leafValue[:], finalizedEpochLeaf)

--- a/smartcontracts/script/DeployerFCT.s.sol
+++ b/smartcontracts/script/DeployerFCT.s.sol
@@ -16,7 +16,8 @@ contract DeployFinalizedCheckpointTracker is Script {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
 
-        fct = new FinalizedCheckpointTracker(beaconRootsContract);
+        // TODO: manage the generalized index better
+        fct = new FinalizedCheckpointTracker(beaconRootsContract, 740);
 
         console.log(address(fct));
         vm.stopBroadcast();

--- a/smartcontracts/script/DeployerFCT.s.sol
+++ b/smartcontracts/script/DeployerFCT.s.sol
@@ -17,7 +17,7 @@ contract DeployFinalizedCheckpointTracker is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         // TODO: manage the generalized index better
-        fct = new FinalizedCheckpointTracker(beaconRootsContract, 740);
+        fct = new FinalizedCheckpointTracker(beaconRootsContract, 744);
 
         console.log(address(fct));
         vm.stopBroadcast();

--- a/smartcontracts/src/FinalizedCheckpointTracker.sol
+++ b/smartcontracts/src/FinalizedCheckpointTracker.sol
@@ -44,6 +44,7 @@ contract FinalizedCheckpointTracker is MerkleProofVerifier, IFinalizedCheckpoint
 
         bytes32 beaconRoot = abi.decode(data, (bytes32));
 
+        // TODO: Recursively prove upwards to avoid security bug
         verifyProof(MerkleRoot.wrap(beaconRoot), proof);
 
         highestFinalizedEpoch = epoch;

--- a/smartcontracts/src/FinalizedCheckpointTracker.sol
+++ b/smartcontracts/src/FinalizedCheckpointTracker.sol
@@ -13,21 +13,23 @@ import "./IFinalizedCheckpointTracker.sol";
 contract FinalizedCheckpointTracker is MerkleProofVerifier, IFinalizedCheckpointTracker {
     using SSZHelper for bytes32;
 
-    /// @inheritdoc IFinalizedCheckpointTracker
-    address public immutable override beaconRootsAddress;
+    address public immutable beaconRootsAddress;
 
-    /// @inheritdoc IFinalizedCheckpointTracker
-    uint256 public override highestFinalizedEpoch;
+    uint256 public immutable leafIndex;
 
-    /// @inheritdoc IFinalizedCheckpointTracker
-    uint256 public override highestFinalizedTimestamp;
+    uint256 public highestFinalizedEpoch;
+
+    uint256 public highestFinalizedTimestamp;
 
     /**
      * @notice Initializes the contract with the Beacon Roots contract address.
      * @param beaconRootsAddress_ The address of the Beacon Roots contract.
+     * @param leafIndex_ The expected leaf index for the value we want to prove.
+     * We cannot trust the user to give us a valid value
      */
-    constructor(address beaconRootsAddress_) {
+    constructor(address beaconRootsAddress_, uint256 leafIndex_) {
         beaconRootsAddress = beaconRootsAddress_;
+        leafIndex = leafIndex_;
     }
 
     /**
@@ -35,6 +37,7 @@ contract FinalizedCheckpointTracker is MerkleProofVerifier, IFinalizedCheckpoint
      */
     function proveCheckpointFinalized(uint256 timestamp, ProofInputs calldata proof) external override {
         require(timestamp > highestFinalizedTimestamp, AlreadyFinalized());
+        require(proof.index == leafIndex, InvalidProof());
 
         uint256 epoch = proof.value.fromLittleEndian();
         require(epoch > highestFinalizedEpoch, AlreadyFinalized());
@@ -44,7 +47,6 @@ contract FinalizedCheckpointTracker is MerkleProofVerifier, IFinalizedCheckpoint
 
         bytes32 beaconRoot = abi.decode(data, (bytes32));
 
-        // TODO: Recursively prove upwards to avoid security bug
         verifyProof(MerkleRoot.wrap(beaconRoot), proof);
 
         highestFinalizedEpoch = epoch;

--- a/smartcontracts/test/FinalizedCheckpointTracker.t.sol
+++ b/smartcontracts/test/FinalizedCheckpointTracker.t.sol
@@ -11,7 +11,7 @@ contract FinalizedCheckpointTrackerTest is Test, IMerkleProofVerifier {
     address constant beaconRootsContract = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
 
     function setUp() public {
-        fct = new FinalizedCheckpointTracker(beaconRootsContract);
+        fct = new FinalizedCheckpointTracker(beaconRootsContract, 2);
     }
 
     function test_finalizedCheckpointValid_success() public {


### PR DESCRIPTION
My intuition is that intermediate states do not need to be validated given a fixed well-known index